### PR TITLE
fix: backward-compat for ESM etherpad

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "email": "john@mclear.co.uk",
     "url": "http://mclear.co.uk"
   },
-  "version": "1.1.61",
+  "version": "1.1.62",
   "repository": {
     "type": "git",
     "url": "https://github.com/ether/ep_help_bubbles.git"

--- a/static/js/help_bubbles.js
+++ b/static/js/help_bubbles.js
@@ -1,23 +1,23 @@
 'use strict';
 
 exports.eejsBlock_scripts = (hookName, args, cb) => {
-  args.content += require('ep_etherpad-lite/node/eejs/')
+  args.content += require('ep_etherpad-lite/node/eejs')
       .require('ep_help_bubbles/static/js/Bubble.js');
-  args.content += require('ep_etherpad-lite/node/eejs/')
+  args.content += require('ep_etherpad-lite/node/eejs')
       .require('ep_help_bubbles/static/js/jquery.grumble.js');
-  args.content += require('ep_etherpad-lite/node/eejs/')
+  args.content += require('ep_etherpad-lite/node/eejs')
       .require('ep_help_bubbles/static/js/help_bubbles_function.js');
   cb();
 };
 
 exports.eejsBlock_styles = (hookName, args, cb) => {
-  args.content += require('ep_etherpad-lite/node/eejs/')
+  args.content += require('ep_etherpad-lite/node/eejs')
       .require('ep_help_bubbles/static/css/help_bubbles.css');
   cb();
 };
 
 exports.eejsBlock_editbarMenuRight = (hookName, args, cb) => {
-  args.content = require('ep_etherpad-lite/node/eejs/')
+  args.content = require('ep_etherpad-lite/node/eejs')
       .require('ep_help_bubbles/templates/help_bubbles.ejs') + args.content;
   cb();
 };


### PR DESCRIPTION
This PR makes the plugin backward-compatible with the upcoming ESM etherpad branch (ether/etherpad#7605).

**Change:** Remove trailing slash from `require("ep_etherpad-lite/node/eejs/")` → `require("ep_etherpad-lite/node/eejs")`

The trailing-slash form breaks under Node's strict ESM exports map resolution. This change is **backward-compatible** with the current CJS etherpad release.